### PR TITLE
docker-compose: always restart Prometheus container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     command: "--config.file=/etc/prometheus/prometheus.yml --query.max-samples=31250000 --query.max-concurrency=2"
     ports:
       - "9090:9090"
+    restart: always
     depends_on:
       - lndmon
 


### PR DESCRIPTION
Prometheus's OOMs are still not fully solved and can still happen under the stress of
very large queries. Restarting automatically gives the user a chance to undo a harmful query
without having to restart every other container.