### PR TITLE
grafana channel dashboard: remove Lingering HTLC Count panel

### DIFF
--- a/grafana/provisioning/dashboards/channels.json
+++ b/grafana/provisioning/dashboards/channels.json
@@ -15,7 +15,6 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 5,
   "links": [],
   "panels": [
     {
@@ -217,7 +216,7 @@
         "x": 0,
         "y": 8
       },
-      "id": 4,
+      "id": 10,
       "legend": {
         "avg": false,
         "current": false,
@@ -242,10 +241,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "lnd_channels_pending_htlc_count",
+          "expr": "lnd_channels_updates_count",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "num_pending_htlcs",
+          "legendFormat": "total_chan_updates",
           "refId": "A"
         }
       ],
@@ -253,7 +252,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Lingering HTLC Count",
+      "title": "Channel Updates Count",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -354,92 +353,6 @@
       "timeRegions": [],
       "timeShift": null,
       "title": "Channel Count",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "Prometheus",
-      "fill": 1,
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 16
-      },
-      "id": 10,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {},
-      "percentage": false,
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "expr": "lnd_channels_updates_count",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "total_chan_updates",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Channel Updates Count",
       "tooltip": {
         "shared": true,
         "sort": 0,


### PR DESCRIPTION
Closes #8.