### PR TITLE
set default Grafana home dashboard.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,11 @@ services:
       - ./grafana/provisioning/:/etc/grafana/provisioning/
       - grafana-storage:/var/lib/grafana
 
+  post_start:
+    build: ./post_start
+    depends_on:
+      - grafana
+
 volumes:
   grafana-storage:
   prometheus-storage:

--- a/post_start/Dockerfile
+++ b/post_start/Dockerfile
@@ -1,0 +1,6 @@
+FROM alpine
+
+COPY ./script/set_default_graf_dash.sh /bin/
+
+RUN apk --update add curl jq && chmod +x /bin/set_default_graf_dash.sh
+CMD set_default_graf_dash.sh

--- a/post_start/script/set_default_graf_dash.sh
+++ b/post_start/script/set_default_graf_dash.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+echo "Setting Grafana default dashboard..."
+DASH_UID="sJUFc-NWk"
+DASH_ID=0
+for i in 1 2 3 4 5; do
+    curl -H 'Content-Type: application/json' -X GET http://admin:admin@grafana:3000/api/dashboards/uid/$DASH_UID && RESP=$(curl -H 'Content-Type: application/json' -X GET http://admin:admin@grafana:3000/api/dashboards/uid/$DASH_UID) && DASH_ID=$( echo "$RESP" | jq '.dashboard.id' ) && break || sleep 15;
+done
+
+for i in 1 2 3 4 5; do
+    curl -d "{\"homeDashboardId\":$DASH_ID}" -H 'Content-Type: application/json' -X PUT http://admin:admin@grafana:3000/api/org/preferences && break || sleep 15;
+done


### PR DESCRIPTION
Closes #6. Currently this sets the default dashboard to be the Channel State dashboard.