### PR TITLE
dashboards: more accurate CPU usage for the perf dashboard

### DIFF
--- a/grafana/provisioning/dashboards/perf.json
+++ b/grafana/provisioning/dashboards/perf.json
@@ -56,7 +56,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(process_cpu_seconds_total{job=\"lnd\"}[5m])*10",
+          "expr": "irate(process_cpu_seconds_total{job=\"lnd\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "cpu_usage",


### PR DESCRIPTION
In this PR, we attempt to make the current CPU usage graph for `lnd`
more accurate. AFAICT, the `*10` that we had was completely superfluous,
and omitting that seems to produce a more accurate CPU usage reading. In
the future, we may want to use something like [`Node
Exporter`](https://prometheus.io/docs/guides/node-exporter/) as we can
obtain richer information such as the idle CPU time, or the amount of
disk space left on the instance.