### PR TITLE
dashboards: only display heap info for lnd

### DIFF
--- a/grafana/provisioning/dashboards/perf.json
+++ b/grafana/provisioning/dashboards/perf.json
@@ -321,14 +321,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "go_memstats_heap_alloc_bytes",
+          "expr": "go_memstats_heap_alloc_bytes{job=\"lnd\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "heap_alloc_bytes",
           "refId": "A"
         },
         {
-          "expr": "go_memstats_heap_idle_bytes",
+          "expr": "go_memstats_heap_idle_bytes{job=\"lnd\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "heap_idle_bytes",


### PR DESCRIPTION
In this commit, we fix an oversight that would cause us to display heap
information for both `lnd` _and_ `lndmon`. The prior commit that added
this information failed to filter it out for only `lnd`, resulting in a
noisier graph than expected.