### PR TITLE
dashboards: switch to irate for peer bytes sent/recv

### DIFF
--- a/grafana/provisioning/dashboards/peers.json
+++ b/grafana/provisioning/dashboards/peers.json
@@ -142,7 +142,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "deriv(lnd_peer_count[30s])",
+          "expr": "deriv(lnd_peer_count[40s])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "peer_count_deriv",
@@ -228,10 +228,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(lnd_peer_sent_byte)",
+          "expr": "irate(lnd_peer_sent_byte[5m])",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "total_bytes_sent",
+          "legendFormat": "{{ pubkey }}",
           "refId": "A"
         }
       ],
@@ -314,10 +314,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(lnd_peer_recv_byte)",
+          "expr": "irate(lnd_peer_recv_byte[5m])",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "total_recv_bytes",
+          "legendFormat": "{{ pubkey }}",
           "refId": "A"
         }
       ],
@@ -590,7 +590,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(5, lnd_peer_recv_sat)",
+          "expr": "topk(5, lnd_peer_recv_byte)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ pubkey }}",
@@ -727,6 +727,7 @@
       }
     }
   ],
+  "refresh": "5m",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [],
@@ -734,7 +735,7 @@
     "list": []
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {
@@ -765,5 +766,5 @@
   "timezone": "",
   "title": "Peer State",
   "uid": "WZoVj0HZk",
-  "version": 12
+  "version": 13
 }


### PR DESCRIPTION
In this commit, we switch to using an `irate` over the past minute for
the peer graphs. The cumulative graph wasn't very helpful, since it can
be skewed when peers connect/reconnect. This new `irate` format is
better as you can at a glance, spot anomalies (spikes in sent/recv)
easily.

We also fix some graphs that were graph satoshis instead of bytes (kek),
and use a longer interval for the peer flappiness graph to make it
smoother.

Nu graphs: 

![Screen Shot 2019-07-31 at 9 14 24 PM](https://user-images.githubusercontent.com/998190/62265398-db982580-b3d8-11e9-99a2-f5bcd68c26df.png)

![Screen Shot 2019-07-31 at 9 14 17 PM](https://user-images.githubusercontent.com/998190/62265400-dfc44300-b3d8-11e9-8e0c-a7dc6c3785b1.png)
