### PR TITLE
Kubernetes compatible dashboards

### DIFF
--- a/grafana/provisioning/dashboards/chain.json
+++ b/grafana/provisioning/dashboards/chain.json
@@ -393,7 +393,7 @@
   ],
   "schemaVersion": 18,
   "style": "dark",
-  "tags": [],
+  "tags": ["ligithning-network"],
   "templating": {
     "list": []
   },

--- a/grafana/provisioning/dashboards/chain.json
+++ b/grafana/provisioning/dashboards/chain.json
@@ -56,14 +56,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "lnd_wallet_balance_confirmed_sat",
+          "expr": "lnd_wallet_balance_confirmed_sat{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "conf_sat",
           "refId": "A"
         },
         {
-          "expr": "lnd_wallet_balance_unconfirmed_sat",
+          "expr": "lnd_wallet_balance_unconfirmed_sat{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "unconf_sat",
@@ -149,14 +149,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "lnd_utxos_count_confirmed_total",
+          "expr": "lnd_utxos_count_confirmed_total{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "num_conf_utxos",
           "refId": "A"
         },
         {
-          "expr": "lnd_utxos_count_unconfirmed_total",
+          "expr": "lnd_utxos_count_unconfirmed_total{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "num_unconf_utxos",
@@ -242,21 +242,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "lnd_utxos_sizes_avg_sat",
+          "expr": "lnd_utxos_sizes_avg_sat{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg_utxo_size_sat",
           "refId": "A"
         },
         {
-          "expr": "lnd_utxos_sizes_max_sat",
+          "expr": "lnd_utxos_sizes_max_sat{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max_utxo_size_sat",
           "refId": "B"
         },
         {
-          "expr": "lnd_utxos_sizes_min_sat",
+          "expr": "lnd_utxos_sizes_min_sat{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "min_utxo_size_sat",
@@ -342,7 +342,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "lnd_chain_block_height",
+          "expr": "lnd_chain_block_height{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "block_height",

--- a/grafana/provisioning/dashboards/chain.json
+++ b/grafana/provisioning/dashboards/chain.json
@@ -395,7 +395,78 @@
   "style": "dark",
   "tags": ["ligithning-network"],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "tags": [],
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "",
+          "value": ""
+        },
+        "datasource": "$datasource",
+        "definition": "label_values(kube_pod_info, namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": "label_values(kube_pod_info, namespace)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "",
+          "value": ""
+        },
+        "datasource": "$datasource",
+        "definition": "label_values(lnd_chain_block_timestamp{namespace=\"$namespace\"}, job)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "job",
+        "multi": false,
+        "name": "job",
+        "options": [],
+        "query": "label_values(lnd_chain_block_timestamp{namespace=\"$namespace\"}, job)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
   },
   "time": {
     "from": "now-6h",

--- a/grafana/provisioning/dashboards/channels.json
+++ b/grafana/provisioning/dashboards/channels.json
@@ -1036,7 +1036,7 @@
   ],
   "schemaVersion": 18,
   "style": "dark",
-  "tags": [],
+  "tags": ["ligithning-network"],
   "templating": {
     "list": []
   },

--- a/grafana/provisioning/dashboards/channels.json
+++ b/grafana/provisioning/dashboards/channels.json
@@ -1038,7 +1038,77 @@
   "style": "dark",
   "tags": ["ligithning-network"],
   "templating": {
-    "list": []
+    "list": [{
+        "current": {
+          "tags": [],
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "",
+          "value": ""
+        },
+        "datasource": "$datasource",
+        "definition": "label_values(kube_pod_info, namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": "label_values(kube_pod_info, namespace)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "",
+          "value": ""
+        },
+        "datasource": "$datasource",
+        "definition": "label_values(lnd_chain_block_timestamp{namespace=\"$namespace\"}, job)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "job",
+        "multi": false,
+        "name": "job",
+        "options": [],
+        "query": "label_values(lnd_chain_block_timestamp{namespace=\"$namespace\"}, job)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
   },
   "time": {
     "from": "now-6h",

--- a/grafana/provisioning/dashboards/channels.json
+++ b/grafana/provisioning/dashboards/channels.json
@@ -56,21 +56,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "lnd_channels_pending_total",
+          "expr": "lnd_channels_pending_total{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "num_pending_chans",
           "refId": "A"
         },
         {
-          "expr": "lnd_channels_active_total",
+          "expr": "lnd_channels_active_total{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "num_active_chans",
           "refId": "B"
         },
         {
-          "expr": "lnd_channels_inactive_total",
+          "expr": "lnd_channels_inactive_total{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "num_inactive_chans",
@@ -156,28 +156,28 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "lnd_channels_pending_balance_sat > 0",
+          "expr": "lnd_channels_pending_balance_sat{namespace=\"$namespace\",job=\"$job\"} > 0",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "pending_open_sat",
           "refId": "A"
         },
         {
-          "expr": "lnd_channels_open_balance_sat",
+          "expr": "lnd_channels_open_balance_sat{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "channels_sat",
           "refId": "B"
         },
         {
-          "expr": "lnd_wallet_balance_unconfirmed_sat > 0",
+          "expr": "lnd_wallet_balance_unconfirmed_sat{namespace=\"$namespace\",job=\"$job\"} > 0",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "unconf_balance_sat",
           "refId": "C"
         },
         {
-          "expr": "lnd_wallet_balance_confirmed_sat",
+          "expr": "lnd_wallet_balance_confirmed_sat{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "conf_balance_sat",
@@ -263,7 +263,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(lnd_channels_bandwidth_outgoing_sat)",
+          "expr": "sum(lnd_channels_bandwidth_outgoing_sat{namespace=\"$namespace\",job=\"$job\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -271,7 +271,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(lnd_channels_bandwidth_incoming_sat)",
+          "expr": "sum(lnd_channels_bandwidth_incoming_sat{namespace=\"$namespace\",job=\"$job\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -358,7 +358,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "lnd_channels_pending_htlc_count > 0",
+          "expr": "lnd_channels_pending_htlc_count{namespace=\"$namespace\",job=\"$job\"} > 0",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "cid: {{ chan_id }}",
@@ -444,7 +444,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(5, lnd_channels_sent_sat + lnd_channels_received_sat > 0)",
+          "expr": "topk(5, lnd_channels_sent_sat + lnd_channels_received_sat{namespace=\"$namespace\",job=\"$job\"} > 0)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "cid: {{ chan_id }}",
@@ -532,7 +532,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(5, lnd_channels_updates_count)",
+          "expr": "topk(5, lnd_channels_updates_count{namespace=\"$namespace\",job=\"$job\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "cid: {{ chan_id }}",
@@ -619,7 +619,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(lnd_channels_commit_fee)",
+          "expr": "sum(lnd_channels_commit_fee{namespace=\"$namespace\",job=\"$job\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "total_commit_fees",
@@ -705,21 +705,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(lnd_channels_fee_per_kw)",
+          "expr": "max(lnd_channels_fee_per_kw{namespace=\"$namespace\",job=\"$job\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max_fee_per_kw",
           "refId": "A"
         },
         {
-          "expr": "min(lnd_channels_fee_per_kw)",
+          "expr": "min(lnd_channels_fee_per_kw{namespace=\"$namespace\",job=\"$job\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "min_fee_per_kw",
           "refId": "B"
         },
         {
-          "expr": "avg(lnd_channels_fee_per_kw)",
+          "expr": "avg(lnd_channels_fee_per_kw{namespace=\"$namespace\",job=\"$job\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg_fee_per_kw",
@@ -807,7 +807,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "lnd_channels_bandwidth_incoming_sat > 20000",
+          "expr": "lnd_channels_bandwidth_incoming_sat{namespace=\"$namespace\",job=\"$job\"} > 20000",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -897,7 +897,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "lnd_channels_bandwidth_outgoing_sat > 20000",
+          "expr": "lnd_channels_bandwidth_outgoing_sat{namespace=\"$namespace\",job=\"$job\"} > 20000",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "chan_id: {{chan_id}}",

--- a/grafana/provisioning/dashboards/network.json
+++ b/grafana/provisioning/dashboards/network.json
@@ -56,14 +56,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "lnd_graph_nodes_count",
+          "expr": "lnd_graph_nodes_count{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "num_graph_nodes",
           "refId": "A"
         },
         {
-          "expr": "lnd_graph_edges_count",
+          "expr": "lnd_graph_edges_count{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "num_graph_edges",
@@ -154,7 +154,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "lnd_graph_chan_capacity_sat/1e8",
+          "expr": "lnd_graph_chan_capacity_sat{namespace=\"$namespace\",job=\"$job\"}/1e8",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "total_chans_btc",
@@ -248,7 +248,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "lnd_graph_nodes_count",
+          "expr": "lnd_graph_nodes_count{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "num_nodes",
@@ -339,7 +339,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "lnd_graph_edges_count",
+          "expr": "lnd_graph_edges_count{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "channel_count",
@@ -434,14 +434,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "lnd_graph_max_htlc_msat_avg / 1000",
+          "expr": "lnd_graph_max_htlc_msat_avg{namespace=\"$namespace\",job=\"$job\"} / 1000",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max_htlc_avg",
           "refId": "A"
         },
         {
-          "expr": "lnd_graph_max_htlc_msat_median / 1000",
+          "expr": "lnd_graph_max_htlc_msat_median{namespace=\"$namespace\",job=\"$job\"} / 1000",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max_htlc_median",
@@ -527,14 +527,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "lnd_graph_min_htlc_msat_avg / 1000",
+          "expr": "lnd_graph_min_htlc_msat_avg{namespace=\"$namespace\",job=\"$job\"} / 1000",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "min_htlc_sat",
           "refId": "A"
         },
         {
-          "expr": "lnd_graph_min_htlc_msat_median / 1000",
+          "expr": "lnd_graph_min_htlc_msat_median{namespace=\"$namespace\",job=\"$job\"} / 1000",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "median_min_htlc",
@@ -620,14 +620,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "lnd_graph_timelock_delta_median",
+          "expr": "lnd_graph_timelock_delta_median{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "time_lock_delta_median",
           "refId": "A"
         },
         {
-          "expr": "lnd_graph_timelock_delta_avg",
+          "expr": "lnd_graph_timelock_delta_avg{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "time_lock_delta_avg",
@@ -713,14 +713,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "lnd_graph_outdegree_max",
+          "expr": "lnd_graph_outdegree_max{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max_out_degree",
           "refId": "A"
         },
         {
-          "expr": "lnd_graph_outdegree_avg",
+          "expr": "lnd_graph_outdegree_avg{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg_out_degree",
@@ -806,14 +806,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(lnd_graph_fee_rate_msat_avg / 1000000) ",
+          "expr": "(lnd_graph_fee_rate_msat_avg{namespace=\"$namespace\",job=\"$job\"} / 1000000) ",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg_fee_rate",
           "refId": "A"
         },
         {
-          "expr": "lnd_graph_fee_rate_msat_median / 1000000",
+          "expr": "lnd_graph_fee_rate_msat_median{namespace=\"$namespace\",job=\"$job\"} / 1000000",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "median_fee_rate",

--- a/grafana/provisioning/dashboards/network.json
+++ b/grafana/provisioning/dashboards/network.json
@@ -865,7 +865,7 @@
   ],
   "schemaVersion": 18,
   "style": "dark",
-  "tags": [],
+  "tags": ["ligithning-network"],
   "templating": {
     "list": []
   },

--- a/grafana/provisioning/dashboards/network.json
+++ b/grafana/provisioning/dashboards/network.json
@@ -867,7 +867,77 @@
   "style": "dark",
   "tags": ["ligithning-network"],
   "templating": {
-    "list": []
+    "list": [{
+        "current": {
+          "tags": [],
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "",
+          "value": ""
+        },
+        "datasource": "$datasource",
+        "definition": "label_values(kube_pod_info, namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": "label_values(kube_pod_info, namespace)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "",
+          "value": ""
+        },
+        "datasource": "$datasource",
+        "definition": "label_values(lnd_chain_block_timestamp{namespace=\"$namespace\"}, job)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "job",
+        "multi": false,
+        "name": "job",
+        "options": [],
+        "query": "label_values(lnd_chain_block_timestamp{namespace=\"$namespace\"}, job)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
   },
   "time": {
     "from": "now-6h",

--- a/grafana/provisioning/dashboards/peers.json
+++ b/grafana/provisioning/dashboards/peers.json
@@ -56,7 +56,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "lnd_peer_count",
+          "expr": "lnd_peer_count{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "num_peers",
@@ -142,7 +142,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "deriv(lnd_peer_count[40s])",
+          "expr": "deriv(lnd_peer_count{namespace=\"$namespace\",job=\"$job\"}[40s])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "peer_count_deriv",
@@ -228,7 +228,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(lnd_peer_sent_byte[5m])",
+          "expr": "irate(lnd_peer_sent_byte{namespace=\"$namespace\",job=\"$job\"}[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ pubkey }}",
@@ -314,7 +314,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(lnd_peer_recv_byte[5m])",
+          "expr": "irate(lnd_peer_recv_byte{namespace=\"$namespace\",job=\"$job\"}[5m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ pubkey }}",
@@ -400,21 +400,21 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "min((lnd_peer_ping_time_microsecond > 0) / 1000)",
+          "expr": "min((lnd_peer_ping_time_microsecond{namespace=\"$namespace\",job=\"$job\"} > 0) / 1000)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "min_ping_ms ",
           "refId": "A"
         },
         {
-          "expr": "max(lnd_peer_ping_time_microsecond / 1000)",
+          "expr": "max(lnd_peer_ping_time_microsecond{namespace=\"$namespace\",job=\"$job\"} / 1000)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "max_ping_ms",
           "refId": "B"
         },
         {
-          "expr": "avg(lnd_peer_ping_time_microsecond / 1000)",
+          "expr": "avg(lnd_peer_ping_time_microsecond{namespace=\"$namespace\",job=\"$job\"} / 1000)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "avg_ping_ms",
@@ -502,7 +502,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(5, lnd_peer_sent_byte)",
+          "expr": "topk(5, lnd_peer_sent_byte{namespace=\"$namespace\",job=\"$job\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ pubkey }}",
@@ -590,7 +590,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(5, lnd_peer_recv_byte)",
+          "expr": "topk(5, lnd_peer_recv_byte{namespace=\"$namespace\",job=\"$job\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ pubkey }}",
@@ -678,7 +678,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(5, lnd_peer_sent_sat + lnd_peer_recv_sat > 0)",
+          "expr": "topk(5, lnd_peer_sent_sat{namespace=\"$namespace\",job=\"$job\"} + lnd_peer_recv_sat{namespace=\"$namespace\",job=\"$job\"} > 0)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ pubkey }} ",

--- a/grafana/provisioning/dashboards/peers.json
+++ b/grafana/provisioning/dashboards/peers.json
@@ -730,7 +730,7 @@
   "refresh": "5m",
   "schemaVersion": 18,
   "style": "dark",
-  "tags": [],
+  "tags": ["ligithning-network"],
   "templating": {
     "list": []
   },

--- a/grafana/provisioning/dashboards/peers.json
+++ b/grafana/provisioning/dashboards/peers.json
@@ -732,7 +732,78 @@
   "style": "dark",
   "tags": ["ligithning-network"],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "tags": [],
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "",
+          "value": ""
+        },
+        "datasource": "$datasource",
+        "definition": "label_values(kube_pod_info, namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": "label_values(kube_pod_info, namespace)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "",
+          "value": ""
+        },
+        "datasource": "$datasource",
+        "definition": "label_values(lnd_chain_block_timestamp{namespace=\"$namespace\"}, job)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "job",
+        "multi": false,
+        "name": "job",
+        "options": [],
+        "query": "label_values(lnd_chain_block_timestamp{namespace=\"$namespace\"}, job)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
   },
   "time": {
     "from": "now-30m",

--- a/grafana/provisioning/dashboards/perf.json
+++ b/grafana/provisioning/dashboards/perf.json
@@ -56,7 +56,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(process_cpu_seconds_total{job=\"$job\"}[1m])",
+          "expr": "irate(process_cpu_seconds_total{namespace=\"$namespace\",job=\"$job\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "cpu_usage",
@@ -142,14 +142,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "process_resident_memory_bytes{job=\"$job\"}",
+          "expr": "process_resident_memory_bytes{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "res_mem",
           "refId": "A"
         },
         {
-          "expr": "process_virtual_memory_bytes{job=\"$job\"}",
+          "expr": "process_virtual_memory_bytes{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "virt_mem",
@@ -235,7 +235,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "go_gc_duration_seconds{job=\"$job\"}",
+          "expr": "go_gc_duration_seconds{namespace=\"$namespace\",job=\"$job\"}",
           "format": "heatmap",
           "instant": false,
           "intervalFactor": 1,
@@ -321,35 +321,35 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "go_memstats_heap_alloc_bytes{job=\"$job\"}",
+          "expr": "go_memstats_heap_alloc_bytes{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "heap_alloc_bytes",
           "refId": "A"
         },
         {
-          "expr": "go_memstats_heap_idle_bytes{job=\"$job\"}",
+          "expr": "go_memstats_heap_idle_bytes{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "heap_idle_bytes",
           "refId": "B"
         },
         {
-          "expr": "go_memstats_heap_inuse_bytes{job=\"$job\"}",
+          "expr": "go_memstats_heap_inuse_bytes{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "heap_inuse_bytes",
           "refId": "C"
         },
         {
-          "expr": "go_memstats_heap_sys_bytes{job=\"$job\"}",
+          "expr": "go_memstats_heap_sys_bytes{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "heap_sys_bytes",
           "refId": "D"
         },
         {
-          "expr": "go_memstats_heap_released_bytes{job=\"$job\"}",
+          "expr": "go_memstats_heap_released_bytes{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "heap_release_bytes",
@@ -435,7 +435,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "go_memstats_heap_objects{job=\"$job\"}",
+          "expr": "go_memstats_heap_objects{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "num_heap_objects",
@@ -521,7 +521,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "go_goroutines{job=\"$job\"}",
+          "expr": "go_goroutines{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "num_goroutines",
@@ -607,7 +607,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "process_open_fds{job=\"$job\"}",
+          "expr": "process_open_fds{namespace=\"$namespace\",job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "open_fds",

--- a/grafana/provisioning/dashboards/perf.json
+++ b/grafana/provisioning/dashboards/perf.json
@@ -56,7 +56,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(process_cpu_seconds_total{job=\"lnd\"}[1m])",
+          "expr": "irate(process_cpu_seconds_total{job=\"$job\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "cpu_usage",
@@ -142,14 +142,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "process_resident_memory_bytes{job=\"lnd\"}",
+          "expr": "process_resident_memory_bytes{job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "res_mem",
           "refId": "A"
         },
         {
-          "expr": "process_virtual_memory_bytes{job=\"lnd\"}",
+          "expr": "process_virtual_memory_bytes{job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "virt_mem",
@@ -235,7 +235,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "go_gc_duration_seconds{job=\"lnd\"}",
+          "expr": "go_gc_duration_seconds{job=\"$job\"}",
           "format": "heatmap",
           "instant": false,
           "intervalFactor": 1,
@@ -321,35 +321,35 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "go_memstats_heap_alloc_bytes{job=\"lnd\"}",
+          "expr": "go_memstats_heap_alloc_bytes{job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "heap_alloc_bytes",
           "refId": "A"
         },
         {
-          "expr": "go_memstats_heap_idle_bytes{job=\"lnd\"}",
+          "expr": "go_memstats_heap_idle_bytes{job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "heap_idle_bytes",
           "refId": "B"
         },
         {
-          "expr": "go_memstats_heap_inuse_bytes{job=\"lnd\"}",
+          "expr": "go_memstats_heap_inuse_bytes{job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "heap_inuse_bytes",
           "refId": "C"
         },
         {
-          "expr": "go_memstats_heap_sys_bytes{job=\"lnd\"}",
+          "expr": "go_memstats_heap_sys_bytes{job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "heap_sys_bytes",
           "refId": "D"
         },
         {
-          "expr": "go_memstats_heap_released_bytes{job=\"lnd\"}",
+          "expr": "go_memstats_heap_released_bytes{job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "heap_release_bytes",
@@ -435,7 +435,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "go_memstats_heap_objects{job=\"lnd\"}",
+          "expr": "go_memstats_heap_objects{job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "num_heap_objects",
@@ -521,7 +521,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "go_goroutines{job=\"lnd\"}",
+          "expr": "go_goroutines{job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "num_goroutines",
@@ -607,7 +607,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "process_open_fds{job=\"lnd\"}",
+          "expr": "process_open_fds{job=\"$job\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "open_fds",
@@ -661,7 +661,78 @@
   "style": "dark",
   "tags": ["ligithning-network"],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "tags": [],
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "",
+          "value": ""
+        },
+        "datasource": "$datasource",
+        "definition": "label_values(kube_pod_info, namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": "label_values(kube_pod_info, namespace)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "",
+          "value": ""
+        },
+        "datasource": "$datasource",
+        "definition": "label_values(lnd_chain_block_timestamp{namespace=\"$namespace\"}, job)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "job",
+        "multi": false,
+        "name": "job",
+        "options": [],
+        "query": "label_values(lnd_chain_block_timestamp{namespace=\"$namespace\"}, job)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
   },
   "time": {
     "from": "now-3h",

--- a/grafana/provisioning/dashboards/perf.json
+++ b/grafana/provisioning/dashboards/perf.json
@@ -659,7 +659,7 @@
   "refresh": false,
   "schemaVersion": 18,
   "style": "dark",
-  "tags": [],
+  "tags": ["ligithning-network"],
   "templating": {
     "list": []
   },


### PR DESCRIPTION
Hi, 

I've been working on running lnd on kubernetes. Using lndmon with grafana/prometheus is awsome for visibility. 

However, the provided dashboards don't work that well if you run multiple nodes on the same cluster because you don't have a way to filter by node and all the metrics are mixed together.

This PR adds some variables to filter the metrics by:
- **datasource**: this is useful if you have multiple nodes scraped by different prometheus instances.
- **namespace**: to filter by namespace :)
- **job**: to filter by job.

I also added the `lightning-network` tag for the dashboards. (this may have been done in a separated pr)

These branch dashboards are used in a helm chart I wrote but I would be better if we can use the "official" dashboard provided in this repo. https://github.com/budacom/helm-lnd

![image](https://user-images.githubusercontent.com/228037/63617735-3546d680-c5b8-11e9-88ac-789d2d07c7b6.png)

#### Note
> ~I'm not really sure how these changes affect the use of the docker-compose deployment proposed in the repo. That is why I'm marking this PR as draf, it would be asewome to iterate on the changes to make them compatible, of find a way to provide dashboards of all kind of deployments.~
> I have made some changes so it works both in the proposed deployment and in kubernetes using default labels namespace and job
