### PR TITLE
Fix Build: Get zombie channel count from network info

### DIFF
--- a/collectors/graph_collector.go
+++ b/collectors/graph_collector.go
@@ -292,10 +292,6 @@ func (g *GraphCollector) Collect(ch chan<- prometheus.Metric) {
 		g.numNodesDesc, prometheus.GaugeValue,
 		float64(len(resp.Nodes)),
 	)
-	ch <- prometheus.MustNewConstMetric(
-		g.numZombiesDesc, prometheus.GaugeValue,
-		float64(resp.NumZombies),
-	)
 
 	g.collectRoutingPolicyMetrics(ch, resp.Edges)
 
@@ -306,6 +302,11 @@ func (g *GraphCollector) Collect(ch chan<- prometheus.Metric) {
 		graphLogger.Error(err)
 		return
 	}
+
+	ch <- prometheus.MustNewConstMetric(
+		g.numZombiesDesc, prometheus.GaugeValue,
+		float64(networkInfo.NumZombieChans),
+	)
 
 	ch <- prometheus.MustNewConstMetric(
 		g.avgOutDegreeDesc, prometheus.GaugeValue,


### PR DESCRIPTION
`docker-compose build` is failing with:
```
# github.com/lightninglabs/lndmon/collectors
../../collectors/graph_collector.go:297:15: resp.NumZombies undefined (type *lnrpc.ChannelGraph has no field or method NumZombies)
ERROR: Service 'lndmon' failed to build: The command '/bin/sh -c cd /go/src/github.com/lightninglabs/lndmon/cmd/lndmon && go build' returned a non-zero code: 2

```

Probably related to #49, although I didn't check all the way back to v0.7.1 for the proto change so I will get somebody else to reproduce.  