### PR TITLE
Add Channel Uptime Percentage

### DIFF
--- a/grafana/provisioning/dashboards/channels.json
+++ b/grafana/provisioning/dashboards/channels.json
@@ -944,6 +944,94 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "description": "Uptime percentage of remote peer that we have the channel with. ",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "id": 22,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "lnd_channel_uptime_percentage",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "cid: {{ chan_id }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Channel Uptime Percentage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": "1",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "schemaVersion": 18,


### PR DESCRIPTION
This PR adds the remote node's uptime percentage to the node stats dashboard per channel we have open. This change relies on the experimental uptime field in `lnstchannels``.

<img width="992" alt="channel uptime" src="https://user-images.githubusercontent.com/42311294/70438214-0173bc00-1a96-11ea-8b1b-6c72dc995b4b.png">

This change could be generalized to adding uptime for all peers if we updated peer tracking to `listpeers` in lnd (which may be worth doing), or moved onto the peers dashboard if we call `listchannels` in the peers collector then just set uptime for the peers that we currently have channels for. 