### PR TITLE
Improve error handling on startup

### DIFF
--- a/collectors/prometheus.go
+++ b/collectors/prometheus.go
@@ -73,7 +73,7 @@ func NewPrometheusExporter(cfg *PrometheusConfig, lnd lnrpc.LightningClient) *Pr
 
 // Start registers all relevant metrics with the Prometheus library, then
 // launches the HTTP server that Prometheus will hit to scrape our metrics.
-func (p *PrometheusExporter) Start() error {
+func (p *PrometheusExporter) Start(out chan<- error) error {
 	err := initLogRotator(
 		filepath.Join(p.cfg.LogDir, defaultLogFilename),
 		defaultLogFileSize,
@@ -99,7 +99,7 @@ func (p *PrometheusExporter) Start() error {
 	// scape our metrics.
 	go func() {
 		http.Handle("/metrics", promhttp.Handler())
-		Logger.Info(http.ListenAndServe(p.cfg.ListenAddr, nil))
+		out <- http.ListenAndServe(p.cfg.ListenAddr, nil)
 	}()
 
 	return nil

--- a/lndmon.go
+++ b/lndmon.go
@@ -1,6 +1,7 @@
 package lndmon
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/signal"
@@ -9,6 +10,7 @@ import (
 	flags "github.com/jessevdk/go-flags"
 	"github.com/lightninglabs/lndmon/collectors"
 	"github.com/lightninglabs/loop/lndclient"
+	"github.com/lightningnetwork/lnd/lnrpc"
 )
 
 // Main is the true entrypoint to lndmon.
@@ -36,6 +38,12 @@ func start() error {
 	)
 	if err != nil {
 		return err
+	}
+
+	// make sure we're able to send a basic request
+	_, err = lnd.GetInfo(context.Background(), &lnrpc.GetInfoRequest{})
+	if err != nil {
+		return fmt.Errorf("could not query LND: %w", err)
 	}
 
 	// Start our Prometheus exporter. This exporter spawns a goroutine


### PR DESCRIPTION
In this PR we change a couple of things: 
1. Exit from main if the Prometheus exporter fails to start.
2. Query LND (`GetInfo`) on startup, to make sure that we can connect to LND before proceeding. There's no point in exporting metrics if we can't connect to LND, so this should be caught early. 