### PR TITLE
collectors: add proper scraping http error logging, continue if error encountered

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine as builder
+FROM golang:1.14-alpine as builder
 
 # Install build dependencies such as git and glide.
 RUN apk add --no-cache git gcc musl-dev

--- a/collectors/prometheus.go
+++ b/collectors/prometheus.go
@@ -115,7 +115,8 @@ func (p *PrometheusExporter) Start() error {
 		promHandler := promhttp.InstrumentMetricHandler(
 			prometheus.DefaultRegisterer,
 			promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{
-				ErrorLog: errorLogger,
+				ErrorLog:      errorLogger,
+				ErrorHandling: promhttp.ContinueOnError,
 			}),
 		)
 		http.Handle("/metrics", promHandler)


### PR DESCRIPTION
In this PR, we hook up a proper error logger for `promhttp`, which means that we'll now get error logging if Prometheus encounters an error during scraping. We also modify the default arguments to allow the scraper to continue if if runs into any errors along the way. 