### PR TITLE
config: allow specifying of macaroon directory and name

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,7 +1,18 @@
 package lndmon
 
 import (
+	"github.com/btcsuite/btcutil"
 	"github.com/lightninglabs/lndmon/collectors"
+)
+
+var (
+	// defaultMacaroonDir is the default path that we use to point lndmon
+	// to our macaroon. This default works for using lndmon in our docker
+	// compose setup.
+	defaultMacaroonDir = btcutil.AppDataDir("lnd", false)
+
+	// defaultMacaroon is the default macaroon that we use for lndmon.
+	defaultMacaroon = "readonly.macaroon"
 )
 
 type lndConfig struct {
@@ -14,6 +25,9 @@ type lndConfig struct {
 
 	// MacaroonDir is the path to lnd macaroons.
 	MacaroonDir string `long:"macaroondir" description:"Path to lnd macaroons"`
+
+	// MacaroonName is the name of the macaroon in macaroon dir to use.
+	MacaroonName string `long:"macaroonname" description:"The name of our macaroon in macaroon dir to use."`
 
 	// TLSPath is the path to the lnd TLS certificate.
 	TLSPath string `long:"tlspath" description:"Path to lnd tls certificate"`
@@ -34,8 +48,10 @@ type config struct {
 var defaultConfig = config{
 	Prometheus: collectors.DefaultConfig(),
 	Lnd: &lndConfig{
-		Host:    "localhost:10009",
-		Network: "mainnet",
+		Host:         "localhost:10009",
+		Network:      "mainnet",
+		MacaroonDir:  defaultMacaroonDir,
+		MacaroonName: defaultMacaroon,
 	},
 }
 

--- a/lndmon.go
+++ b/lndmon.go
@@ -3,6 +3,7 @@ package lndmon
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	flags "github.com/jessevdk/go-flags"
 	"github.com/lightninglabs/lndclient"
@@ -37,10 +38,12 @@ func start() error {
 	// Initialize our lnd client, requiring at least lnd v0.11.
 	lnd, err := lndclient.NewLndServices(
 		&lndclient.LndServicesConfig{
-			LndAddress:         cfg.Lnd.Host,
-			Network:            lndclient.Network(cfg.Lnd.Network),
-			CustomMacaroonPath: "/root/.lnd/readonly.macaroon",
-			TLSPath:            cfg.Lnd.TLSPath,
+			LndAddress: cfg.Lnd.Host,
+			Network:    lndclient.Network(cfg.Lnd.Network),
+			CustomMacaroonPath: filepath.Join(
+				cfg.Lnd.MacaroonDir, cfg.Lnd.MacaroonName,
+			),
+			TLSPath: cfg.Lnd.TLSPath,
 			CheckVersion: &verrpc.Version{
 				AppMajor: 0,
 				AppMinor: 11,


### PR DESCRIPTION
Previous changes set lndmon to only use the macaroon path that is set
when we use docker-compose and the mounted macaroons volume. This commit
updates lndmon to use the macaroon dir path and adds a macaroon name (so
that macaroons other than the readonly macaroon could be used). This
allows standalone lndmon containers that do not use our docker-compose
setup to specify where their macaroons are.