### PR TITLE
routing: dashboard tweaks

### DIFF
--- a/grafana/provisioning/dashboards/routing.json
+++ b/grafana/provisioning/dashboards/routing.json
@@ -58,7 +58,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(sum by(outcome)(lnd_htlcs_resolved_htlcs{type=\"$HtlcType\"})[5m:1s])",
+          "expr": "increase(sum by(outcome)(lnd_htlcs_resolved_htlcs{type=\"$HtlcType\"})[5m:1s])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{outcome}}",

--- a/grafana/provisioning/dashboards/routing.json
+++ b/grafana/provisioning/dashboards/routing.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 6,
-  "iteration": 1605606404393,
+  "iteration": 1611909070020,
   "links": [],
   "panels": [
     {
@@ -214,11 +214,13 @@
       },
       "id": 6,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "rightSide": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -305,11 +307,12 @@
       },
       "id": 7,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -396,11 +399,12 @@
       },
       "id": 8,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -487,11 +491,12 @@
       },
       "id": 9,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -825,11 +830,12 @@
       },
       "id": 15,
       "legend": {
+        "alignAsTable": true,
         "avg": false,
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -974,5 +980,5 @@
   "timezone": "",
   "title": "Routing",
   "uid": "a-7ouFhGz",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
This PR makes two small changes to the routing dashboard:
1. Show channel ID labels as a table for panels where we may have many channels, this makes it easier to select individual channels and more readable for nodes with many channels
2. Change resolution rate to use `increase` over `irate`, this display the change in our count of settled/failed htlcs