### PR TITLE
collectors: add close metrics

### DIFF
--- a/grafana/provisioning/dashboards/channels.json
+++ b/grafana/provisioning/dashboards/channels.json
@@ -15,7 +15,6 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 8,
   "links": [],
   "panels": [
     {
@@ -59,21 +58,21 @@
           "expr": "lnd_channels_pending_total",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "num_pending_chans",
+          "legendFormat": "{{state}}",
           "refId": "A"
         },
         {
           "expr": "lnd_channels_active_total",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "num_active_chans",
+          "legendFormat": "active",
           "refId": "B"
         },
         {
           "expr": "lnd_channels_inactive_total",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "num_inactive_chans",
+          "legendFormat": "inactive",
           "refId": "C"
         }
       ],
@@ -864,12 +863,100 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
+      "description": "Uptime percentage of remote peer that we have the channel with. ",
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 43
+      },
+      "id": 22,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {},
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "lnd_channel_uptime_percentage",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "cid: {{ chan_id }}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Channel Uptime Percentage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": "1",
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
       "fill": 1,
       "gridPos": {
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 50
       },
       "id": 8,
       "legend": {
@@ -951,15 +1038,14 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "Prometheus",
-      "description": "Uptime percentage of remote peer that we have the channel with. ",
       "fill": 1,
       "gridPos": {
-        "h": 7,
-        "w": 24,
+        "h": 8,
+        "w": 12,
         "x": 0,
-        "y": 34
+        "y": 58
       },
-      "id": 22,
+      "id": 26,
       "legend": {
         "avg": false,
         "current": false,
@@ -980,15 +1066,14 @@
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
-      "stack": true,
+      "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "lnd_channel_uptime_percentage",
+          "expr": "lnd_closed_channels_total",
           "format": "time_series",
-          "hide": false,
           "intervalFactor": 1,
-          "legendFormat": "cid: {{ chan_id }}",
+          "legendFormat": "{{close_type}}",
           "refId": "A"
         }
       ],
@@ -996,7 +1081,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Channel Uptime Percentage",
+      "title": "Closed Channels",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1012,11 +1097,11 @@
       },
       "yaxes": [
         {
-          "format": "percentunit",
+          "format": "short",
           "label": null,
           "logBase": 1,
-          "max": "1",
-          "min": "0",
+          "max": null,
+          "min": null,
           "show": true
         },
         {


### PR DESCRIPTION
This PR adds metrics so that a prometheus alert can be set up when a force-close happens. This is an event that unfortunately still seems to occur occasionally.

Example of an alert that becomes active if at least one channel was force-closed in the past 24 hours:

`round(sum(delta(lnd_closed_channels_total{type="local_force"}[1d]) or delta(lnd_closed_channels_total{type="remote_force"}[1d]) or delta(lnd_channels_pending_total{state="pending_force_close"}[1d]))) > 0`