### PR TITLE
config: add --disablegraph

### DIFF
--- a/config.go
+++ b/config.go
@@ -43,6 +43,9 @@ type config struct {
 
 	// PrimaryNode is the pubkey of the primary node in primary-gateway setups.
 	PrimaryNode string `long:"primarynode" description:"Public key of the primary node in a primary-gateway setup"`
+
+	// DisableGraph disables collection of graph metrics
+	DisableGraph bool `long:"disablegraph" description:"Do not collect graph metrics"`
 }
 
 var defaultConfig = config{

--- a/lndmon.go
+++ b/lndmon.go
@@ -56,7 +56,9 @@ func start() error {
 	}
 	defer lnd.Close()
 
-	monitoringCfg := collectors.MonitoringConfig{}
+	monitoringCfg := collectors.MonitoringConfig{
+		DisableGraph: cfg.DisableGraph,
+	}
 	if cfg.PrimaryNode != "" {
 		primaryNode, err := route.NewVertexFromStr(cfg.PrimaryNode)
 		if err != nil {


### PR DESCRIPTION
`lndmon` is known (reported by multiple users) to cause high cpu load problems for lnd. This is cause by the `DescribeGraph` call which is really too heavy for frequent scraping.

This PR adds a command line flag to disable the graph metrics.