### PR TITLE
use FailureDetail enum for htlc event failures

### DIFF
--- a/collectors/htlcs_collector.go
+++ b/collectors/htlcs_collector.go
@@ -232,14 +232,19 @@ func (h *htlcMonitor) processHtlcEvent(event *routerrpc.HtlcEvent) error {
 
 	case *routerrpc.HtlcEvent_LinkFailEvent:
 		err := h.recordResolution(
-			key, event.EventType, ts, e.LinkFailEvent.FailureString,
+			key, event.EventType, ts, e.LinkFailEvent.FailureDetail.Enum().String(),
 		)
 		if err != nil {
 			return err
 		}
 
 	default:
-		return fmt.Errorf("unknown htlc event type: %T", event)
+		err := h.recordResolution(
+			key, event.EventType, ts, "unknown",
+		)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
`LinkFailEvent.FailureString` is an arbitrary string of undefined length.  

I noticed in my Prometheus a   `feeinsufficient` failure caused a very large label value. 

The Enum of FailureDetail has a short name describing the failure. 


```
failure_reason="feeinsufficient(htlc_amt==xxxxxxxx,_update=(lnwire.channelupdate)_{ 
_signature:_(lnwire.sig)_(len=64_cap=64)_{ __00000000__xxxxxx__|xxxxxx.| __00000010_xxxxxxxx__|o&.i...h..qj.{..| 
__00000020__xxxxxx&]3'...ea...h..<| __00000030__25_18_98_e4_50_cd_c1_1a__ff_f0_bf_b9_b5_08_67_cf__|%...p.........g.| _}, _chainhash:_(chainhash.hash)_(len=32_cap=32)xxxxxx, _shortchannelid:_(lnwire.shortchannelid)_xxxxxx, 
_timestamp:_(uint32)_1646318182, _messageflags:_(lnwire.chanupdatemsgflags)_00000001, _channelflags:_(lnwire.chanupdatechanflags)_00000000, _timelockdelta:_(uint16)_40, 
_htlcminimummsat:_(lnwire.millisatoshi)_1000_msat, _basefee:_(uint32)_0, _feerate:_(uint32)_50, 
_htlcmaximummsat:_(lnwire.millisatoshi)_1600000000_msat, _extraopaquedata:_(lnwire.extraopaquedata)_{ _} } ",

```