### PR TITLE
Prevent sending key count when 0.

### DIFF
--- a/collectors/wallet_collector.go
+++ b/collectors/wallet_collector.go
@@ -198,17 +198,21 @@ func (u *WalletCollector) Collect(ch chan<- prometheus.Metric) {
 		path := account.GetDerivationPath()
 
 		// internal key count.
-		ch <- prometheus.MustNewConstMetric(
-			u.keyCountDesc, prometheus.CounterValue,
-			float64(account.InternalKeyCount),
-			name, addrType, path, "internal",
-		)
+		if account.InternalKeyCount > 0 {
+			ch <- prometheus.MustNewConstMetric(
+				u.keyCountDesc, prometheus.CounterValue,
+				float64(account.InternalKeyCount),
+				name, addrType, path, "internal",
+			)
+		}
 
 		// external key count.
-		ch <- prometheus.MustNewConstMetric(
-			u.keyCountDesc, prometheus.CounterValue,
-			float64(account.ExternalKeyCount),
-			name, addrType, path, "external",
-		)
+		if account.ExternalKeyCount > 0 {
+			ch <- prometheus.MustNewConstMetric(
+				u.keyCountDesc, prometheus.CounterValue,
+				float64(account.ExternalKeyCount),
+				name, addrType, path, "external",
+			)
+		}
 	}
 }


### PR DESCRIPTION
Since the introduction of
https://github.com/lightningnetwork/lnd/commit/afc53d1c52f457ba24dc2a82d0f78e87865113b5,
lnd will create 255 new wallets. Those might never be used but metrics
are being sent, polluting the metric space.

This PR only send metrics when keycount is > 0 on both internal and
external branches.