### PR TITLE
collectors: summarize limbo channel balances to avoid stuck values

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -3,6 +3,7 @@ FROM golang:1.18-buster
 RUN apt-get update && apt-get install -y git
 ENV GOCACHE=/tmp/build/.cache
 ENV GOMODCACHE=/tmp/build/.modcache
+ENV GOFLAGS="-buildvcs=false"
 
 COPY . /tmp/tools
 


### PR DESCRIPTION
This commit changes how we collect limbo balances to calculate summaries instead of separate series by channel, peer, status etc. Having just the summaries makes it possible to correctly select the last known total value which was previously not feasible when summarizing over longer periods due to values with channel/peer specific labels getting "stuck".