### PR TITLE
collectors: remove unneded resoltion when processing final/subscribed htlc events

### DIFF
--- a/collectors/htlcs_collector.go
+++ b/collectors/htlcs_collector.go
@@ -239,16 +239,10 @@ func (h *htlcMonitor) processHtlcEvent(event *routerrpc.HtlcEvent) error {
 		}
 
 	case *routerrpc.HtlcEvent_SubscribedEvent:
-		err := h.recordResolution(key, event.EventType, ts, "")
-		if err != nil {
-			return err
-		}
+		return nil
 
 	case *routerrpc.HtlcEvent_FinalHtlcEvent:
-		err := h.recordResolution(key, event.EventType, ts, "")
-		if err != nil {
-			return err
-		}
+		return nil
 
 	default:
 		return fmt.Errorf("unknown htlc event type: %T", event)


### PR DESCRIPTION
A previous PR (https://github.com/lightninglabs/lndmon/pull/96) introduced a new bug where we forwarded the final and subscribed events to record them as resolution which isn't needed. This PR fixes that problem.