### PR TITLE
Add a toggle to disable the HTLC monitor metrics

### DIFF
--- a/config.go
+++ b/config.go
@@ -49,8 +49,11 @@ type config struct {
 	// PrimaryNode is the pubkey of the primary node in primary-gateway setups.
 	PrimaryNode string `long:"primarynode" description:"Public key of the primary node in a primary-gateway setup"`
 
-	// DisableGraph disables collection of graph metrics
+	// DisableGraph disables collection of graph metrics.
 	DisableGraph bool `long:"disablegraph" description:"Do not collect graph metrics"`
+
+	// DisableHtlc disables the collection of HTLCs metrics.
+	DisableHtlc bool `long:"disablehtlc" description:"Do not collect HTLCs metrics"`
 }
 
 var defaultConfig = config{

--- a/lndmon.go
+++ b/lndmon.go
@@ -59,6 +59,7 @@ func start() error {
 
 	monitoringCfg := collectors.MonitoringConfig{
 		DisableGraph: cfg.DisableGraph,
+		DisableHtlc:  cfg.DisableHtlc,
 	}
 	if cfg.PrimaryNode != "" {
 		primaryNode, err := route.NewVertexFromStr(cfg.PrimaryNode)


### PR DESCRIPTION
Over 76k entries are registered for `lnd_htlcs_resolved_htlcs` on the Prometheus endpoint in less than a week, leading to huge amounts of data being consumed by the Prometheus server (around 10MB per request). 

```
% cat metrics | sort | uniq -c | sort -nr | head -10
65926 lnd_htlcs_resolved_htlcs
8404 lnd_htlcs_resolution_time_bucket
 764 lnd_htlcs_resolution_time_sum
 764 lnd_htlcs_resolution_time_count
  41 lnd_channels_updates_count
  41 lnd_channels_unsettled_balance
  41 lnd_channels_sent_sat
  41 lnd_channels_received_sat
  41 lnd_channels_pending_htlc_count
  41 lnd_channels_fee_per_kw
```