### PR TITLE
Add env vars to the grafana connection of post_start script. 

### DIFF
--- a/post_start/script/set_default_graf_dash.sh
+++ b/post_start/script/set_default_graf_dash.sh
@@ -1,12 +1,19 @@
 #!/bin/sh
 
+# Set your Grafana instance's connection configuration.
+GRAFANA_USER=${GRAFANA_USER:-admin}
+GRAFANA_PASS=${GRAFANA_PASS:-admin}
+GRAFANA_HOST=${GRAFANA_HOST:-grafana}
+GRAFANA_PORT=${GRAFANA_PORT:-3000}
+GRAFANA_URI=${GRAFANA_USER}:${GRAFANA_PASS}@${GRAFANA_HOST}:${GRAFANA_PORT}
+
 echo "Setting Grafana default dashboard..."
 DASH_UID="sJUFc-NWk"
 DASH_ID=0
 for i in 1 2 3 4 5; do
-    curl -H 'Content-Type: application/json' -X GET http://admin:admin@grafana:3000/api/dashboards/uid/$DASH_UID && RESP=$(curl -H 'Content-Type: application/json' -X GET http://admin:admin@grafana:3000/api/dashboards/uid/$DASH_UID) && DASH_ID=$( echo "$RESP" | jq '.dashboard.id' ) && break || sleep 15;
+    curl -H 'Content-Type: application/json' -X GET "http://${GRAFANA_URI}/api/dashboards/uid/$DASH_UID" && RESP=$(curl -H 'Content-Type: application/json' -X GET "http://${GRAFANA_URI}/api/dashboards/uid/$DASH_UID") && DASH_ID=$( echo "$RESP" | jq '.dashboard.id' ) && break || sleep 15;
 done
 
 for i in 1 2 3 4 5; do
-    curl -d "{\"homeDashboardId\":$DASH_ID}" -H 'Content-Type: application/json' -X PUT http://admin:admin@grafana:3000/api/org/preferences && break || sleep 15;
+    curl -d "{\"homeDashboardId\":$DASH_ID}" -H 'Content-Type: application/json' -X PUT "http://${GRAFANA_URI}/api/org/preferences" && break || sleep 15;
 done

--- a/post_start/script/set_default_graf_dash.sh
+++ b/post_start/script/set_default_graf_dash.sh
@@ -5,15 +5,14 @@ GRAFANA_USER=${GRAFANA_USER:-admin}
 GRAFANA_PASS=${GRAFANA_PASS:-admin}
 GRAFANA_HOST=${GRAFANA_HOST:-grafana}
 GRAFANA_PORT=${GRAFANA_PORT:-3000}
-GRAFANA_URI=${GRAFANA_USER}:${GRAFANA_PASS}@${GRAFANA_HOST}:${GRAFANA_PORT}
 
 echo "Setting Grafana default dashboard..."
 DASH_UID="sJUFc-NWk"
 DASH_ID=0
 for i in 1 2 3 4 5; do
-    curl -H 'Content-Type: application/json' -X GET "http://${GRAFANA_URI}/api/dashboards/uid/$DASH_UID" && RESP=$(curl -H 'Content-Type: application/json' -X GET "http://${GRAFANA_URI}/api/dashboards/uid/$DASH_UID") && DASH_ID=$( echo "$RESP" | jq '.dashboard.id' ) && break || sleep 15;
+    curl -H 'Content-Type: application/json' -u "${GRAFANA_USER}:${GRAFANA_PASS}" -X GET http://${GRAFANA_HOST}:${GRAFANA_PORT}/api/dashboards/uid/${DASH_UID} && RESP=$(curl -H 'Content-Type: application/json' -u "${GRAFANA_USER}:${GRAFANA_PASS}" -X GET http://${GRAFANA_HOST}:${GRAFANA_PORT}/api/dashboards/uid/${DASH_UID}) && DASH_ID=$( echo "$RESP" | jq '.dashboard.id' ) && break || sleep 15;
 done
 
 for i in 1 2 3 4 5; do
-    curl -d "{\"homeDashboardId\":$DASH_ID}" -H 'Content-Type: application/json' -X PUT "http://${GRAFANA_URI}/api/org/preferences" && break || sleep 15;
+    curl -d "{\"homeDashboardId\":${DASH_ID}}" -H 'Content-Type: application/json' -u "${GRAFANA_USER}:${GRAFANA_PASS}" -X PUT http://${GRAFANA_HOST}:${GRAFANA_PORT}/api/org/preferences && break || sleep 15;
 done


### PR DESCRIPTION
Added the following env vars in the set_default_graf_dash.sh script, while keeping the default values in case they're not set:

- GRAFANA_USER
- GRAFANA_PASS
- GRAFANA_HOST
- GRAFANA_PORT

This is very helpful when deploying with Docker or in a Kubernetes cluster. You can set the env vars in the docker-compose file, or your kubernetes yaml or helm charts.